### PR TITLE
Avoid crash when no app can open an external link

### DIFF
--- a/app/src/main/java/org/asafonov/accelerace/MyWebViewClient.java
+++ b/app/src/main/java/org/asafonov/accelerace/MyWebViewClient.java
@@ -1,10 +1,12 @@
 package org.asafonov.accelerace;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.webkit.WebResourceRequest;
+import android.widget.Toast;
 
 class MyWebViewClient extends WebViewClient {
 
@@ -15,7 +17,11 @@ class MyWebViewClient extends WebViewClient {
         if (url.substring(0, 5).equals("https")) {
           Uri webpage = Uri.parse(url);
           Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
-          view.getContext().startActivity(intent);
+          try {
+            view.getContext().startActivity(intent);
+          } catch (ActivityNotFoundException e) {
+            Toast.makeText(view.getContext(), "No app found to open this link", Toast.LENGTH_SHORT).show();
+          }
           return true;
         }
 


### PR DESCRIPTION
`MyWebViewClient.shouldOverrideUrlLoading` opens `https` links with `startActivity`. On a device with no browser this throws `ActivityNotFoundException` and crashes the app.

This wraps the launch in a try/catch and shows a short message when no app can open the link. Other links still load in the WebView as before.

Closes #4
